### PR TITLE
Update card images

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ let projectData = [
   },
   {
     projectName: "Binary_To_Decimal_converter",
-    projectImage: "Binary_To_Decimal_converter/binary-to-decimal.png",
+    projectImage: "Binary_To_Decimal_converter/images/logo.png",
     projectUrl: "Binary_To_Decimal_converter/popup.html",
     projectDownload:
       "https://downgit.github.io/#/home?url=https://github.com/ridsuteri/Awesome-Chrome-Extensions/tree/main/Binary_To_Decimal_converter",
@@ -298,7 +298,7 @@ let projectData = [
   },
   {
     projectName: "Control Chrome Tabs",
-    projectImage: "Control_Chrome_Tabs/img/000001.png",
+    projectImage: "ControlChromeTabs/img/000001.png",
     projectUrl: "",
     projectDownload:
       "https://downgit.github.io/#/home?url=https://github.com/ridsuteri/Awesome-Chrome-Extensions/tree/main/Control%20Chrome%20Tabs",
@@ -831,7 +831,7 @@ let projectData = [
   },
   {
     projectName: "Dyslexic Help",
-    projectImage: "DyslexicHelp/images/readme.png",
+    projectImage: "Dyslexic Help/images/readme.png",
     projectUrl: "Dyslexic Help/index.html",
     projectDownload:
       "https://downgit.github.io/#/home?url=https://github.com/ridsuteri/Awesome-Chrome-Extensions/tree/main/Dyslexic%20Help",


### PR DESCRIPTION
### 🛠️ Fixes #481 

Closes #481 

### 👨‍💻 Changes proposed
- Updated project image path in script.js file for the following extensions: Binary_To_Decimal_converter and Control Chrome Tabs

### 📄 Note to reviewers
**Remaining to resolve**:  Dyslexic Help and step-progress-bar

### Important
- Name convention of Dyslexic Help folder is wrong and can be updated by the maintainer only, then the project image path can be updated.
- There is no folder present for step-progress-bar extension.
- I will raise an issue for both of the above problems.

## 📷 Screenshots
![image](https://user-images.githubusercontent.com/83328209/186484176-4de755f2-f05c-472b-8617-137c81abc85e.png)

![image](https://user-images.githubusercontent.com/83328209/186484470-5018082b-b0ad-48a6-86bd-929bd311e69d.png)
